### PR TITLE
Add missing exports to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "module": "dist/index.mjs",
   "svelte": "src/index.js",
   "types": "svelte-focus-trap.d.ts",
+  "exports": {
+    ".": {
+      "types": "./svelte-focus-trap.d.ts",
+      "svelte": "./src/index.js"
+    }
+  },
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w"


### PR DESCRIPTION
Svelte shows a build warning when `svelte-focus-trap` is installed (see issue #11).

```
[vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.

svelte-focus-trap@1.2.0

Please see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition for details.
```

This is because Svelte now requires export conditions instead of the `svelte` field in the package.json (see [here](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition)).

The solution is just to add the export conditions. It is backwards compatible, so it doesn't break the package for old Svelte versions.

Example of how it was done in another project: https://github.com/tinymce/tinymce-svelte/pull/52